### PR TITLE
Use javascript switch for cookie to prevent the caching of the script-tag

### DIFF
--- a/src/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Resources/views/storefront/layout/meta.html.twig
@@ -7,14 +7,20 @@
         <script type="text/javascript" id="wbmTagManger">{% verbatim %}
             window.dataLayer = window.dataLayer || [];
             var googleTag = function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);}
-            {% endverbatim %}{% if wbmGtmCookieEnabled %}{% verbatim %}
-                googleTag(window, document, 'script', 'dataLayer', '{% endverbatim %}{{ gtmContainerId|raw }}{% verbatim %}');
-                googleTag = null;
-            {% endverbatim %}{% else %}{% verbatim %}
+
+            function getCookie(name) {
+                var cookieMatch = document.cookie.match(name + "=(.*?)(;|$)");
+                return cookieMatch && decodeURI(cookieMatch[1]);
+            }
+            var gtmCookieSet = getCookie("wbm-tagmanager-enabled");
+            if (gtmCookieSet == null) {
                 window.wbmGoogleTagmanagerId = '{% endverbatim %}{{ gtmContainerId|raw }}{% verbatim %}';
                 window.wbmScriptIsSet = false;
                 window.googleTag = googleTag;
-            {% endverbatim %}{% endif %}
+            } else {
+                googleTag(window, document, 'script', 'dataLayer', '{% endverbatim %}{{ gtmContainerId|raw }}{% verbatim %}');
+                googleTag = null;
+            }{% endverbatim %}
         </script><!-- WbmTagManagerEcomm Head Snippet End -->{% endif %}
     {% endblock %}
     {% block wbm_layout_head_tag_manager_data_layer_push %}


### PR DESCRIPTION
With http-cache activated in Shopware 6, the script-tag rendered at first page-visit gets cached and subsequent visits render the same script-tag even if the `wbm-tagmanager-enabled` cookie got changed.

Error case:

When page-visits happen before cookies on the page are allowed, those pages are cached with the script-tag rendered when `wbm-tagmanager-enabled` is disabled. If the user now allows cookies on the page and goes back to visit the already cached pages, `googleTag(...)` is not called as of the cached script-tag.

Proposed solution in the pull request:

Test for the activation of the cookie fully on javascript side so the script tag which considers both cases is cached and switches if necessary on page-load.