### PR TITLE
Get SalesChannel specific config

### DIFF
--- a/src/Services/DataLayerModules.php
+++ b/src/Services/DataLayerModules.php
@@ -62,18 +62,18 @@ class DataLayerModules implements DataLayerModulesInterface
         return $modules;
     }
 
-    public function getContainerId(): ?string
+    public function getContainerId($salesChannelId = null): ?string
     {
-        return $this->systemConfigService->get('WbmTagManagerEcomm.config.containerId');
+        return $this->systemConfigService->get('WbmTagManagerEcomm.config.containerId', $salesChannelId);
     }
 
-    public function isActive(): ?bool
+    public function isActive($salesChannelId = null): ?bool
     {
-        return !$this->systemConfigService->get('WbmTagManagerEcomm.config.isInactive');
+        return !$this->systemConfigService->get('WbmTagManagerEcomm.config.isInactive', $salesChannelId);
     }
 
-    public function isTrackingProductClicks(): ?bool
+    public function isTrackingProductClicks($salesChannelId = null): ?bool
     {
-        return $this->systemConfigService->get('WbmTagManagerEcomm.config.isTrackingProductClicks');
+        return $this->systemConfigService->get('WbmTagManagerEcomm.config.isTrackingProductClicks', $salesChannelId);
     }
 }

--- a/src/Subscriber/KernelEventsSubscriber.php
+++ b/src/Subscriber/KernelEventsSubscriber.php
@@ -46,7 +46,8 @@ class KernelEventsSubscriber implements EventSubscriberInterface
 
     public function getDataLayerForXmlHttpRequest(ControllerEvent $event): void
     {
-        $isActive = !empty($this->modules->getContainerId()) && $this->modules->isActive();
+        $salesChannelId = $event->getRequest()->get('sw-sales-channel-id');
+        $isActive = !empty($this->modules->getContainerId($salesChannelId)) && $this->modules->isActive($salesChannelId);
 
         if ($isActive && !$event->getRequest()->cookies->get(self::COOKIE_NAME)) {
             $modules = $this->modules->getModules();

--- a/src/Subscriber/StorefrontRenderSubscriber.php
+++ b/src/Subscriber/StorefrontRenderSubscriber.php
@@ -37,8 +37,8 @@ class StorefrontRenderSubscriber implements EventSubscriberInterface
 
     public function onRender(StorefrontRenderEvent $event): void
     {
-        $containerId = $this->modules->getContainerId();
-        $isActive = !empty($containerId) && $this->modules->isActive();
+        $containerId = $this->modules->getContainerId($event->getSalesChannelContext()->getSalesChannel()->getId());
+        $isActive = !empty($containerId) && $this->modules->isActive($event->getSalesChannelContext()->getSalesChannel()->getId());
         $route = $event->getRequest()->attributes->get('_route');
 
         if (!$isActive) {
@@ -71,7 +71,7 @@ class StorefrontRenderSubscriber implements EventSubscriberInterface
             );
             $event->setParameter(
                 'isTrackingProductClicks',
-                $this->modules->isTrackingProductClicks()
+                $this->modules->isTrackingProductClicks($event->getSalesChannelContext()->getSalesChannel()->getId())
             );
             $event->setParameter(
                 'wbmGtmCookieEnabled',


### PR DESCRIPTION
Currently in the subscriber it fetches the config that is set as 'All saleschannels' but not the config that is set for specific saleschannels. This pull requests fixes this.