### PR TITLE
Fix frontend checkout finish page coupon code

### DIFF
--- a/src/Migration/Migration1609926925FixCouponOrderLineItems.php
+++ b/src/Migration/Migration1609926925FixCouponOrderLineItems.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Wbm\TagManagerEcomm\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+final class Migration1609926925FixCouponOrderLineItems extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1609926925;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $query = <<<SQL
+            UPDATE `wbm_data_layer_properties`
+            SET `value` = '{{ page.order.nestedLineItems.filterByType(\'promotion\')|map(item => item.label)|join(\', \') }}'
+            WHERE `module` = 'frontend.checkout.finish.page' AND `name` = 'coupon';
+SQL;
+
+        $connection->exec($query);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Migration/properties.1609926925.sql
+++ b/src/Migration/properties.1609926925.sql
@@ -1,3 +1,0 @@
-UPDATE `wbm_data_layer_properties`
-SET `value`= '{{ page.order.nestedLineItems.filterByType(\'promotion\')|map(item => item.label)|join(\', \') }}'
-WHERE `module` = 'frontend.checkout.finish.page' AND `name` = 'coupon';

--- a/src/Migration/properties.1609926925.sql
+++ b/src/Migration/properties.1609926925.sql
@@ -1,0 +1,3 @@
+UPDATE `wbm_data_layer_properties`
+SET `value`= '{{ page.order.nestedLineItems.filterByType(\'promotion\')|map(item => item.label)|join(\', \') }}'
+WHERE `module` = 'frontend.checkout.finish.page' AND `name` = 'coupon';


### PR DESCRIPTION
**Environment:** Shopware 6.3.x

If there is an order with promotion that has been finished successfully, I noticed some errors in the logging:

```php.CRITICAL: Uncaught Error: Object of class Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity could not be converted to string {"exception":"[object] (Error(code: 0): Object of class Shopware\\Core\\Checkout\\Order\\Aggregate\\OrderLineItem\\OrderLineItemEntity could not be converted to string at /data/web/releases/xxx/vendor/twig/twig/src/Extension/CoreExtension.php:750)"} []```

This is directly related to this piece of code:

`{{ page.order.nestedLineItems.filterByType('promotion')|map((label) => label)|join(', ') }}`

So the solution was to update the map filter in Twig because it does not behave like the ECMAScript variant.

Signed-off-by: Jelle Deneweth <jelle.deneweth@gmail.com>