### PR TITLE
Feature/refactor addtotcart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+* refactor addtocart: use calculated price from shopware, instead of create a new cart and calculating it again.
+The useless temporary carts will be deleted by migration.
+
 # 2.0.1
 * prevent splitting of impressions when "Push as separate event" is not explicit selected
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "webmatch/tag-manager-sw6",
     "keywords": ["shopware6", "shopware-6", "GTM", "datalayer", "datalayer-configuration", "google-tag-manager", "shopware-plugin"],
     "description": "Google Tag Manager + Enhanced E-Commerce Tracking",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "type": "shopware-platform-plugin",
     "license": "proprietary",
     "require": {

--- a/src/Migration/Migration1631192197DeleteTemporaryCarts.php
+++ b/src/Migration/Migration1631192197DeleteTemporaryCarts.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Wbm\TagManagerEcomm\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1631192197DeleteTemporaryCarts extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1631192197;
+    }
+
+    public function update(Connection $connection): void
+    {
+        // remove temporary carts created by this plugin
+        $connection->exec('
+            DELETE FROM cart WHERE token LIKE \'temporaryToken.%\';
+        ');
+        $connection->exec('
+            UPDATE wbm_data_layer_properties
+            SET `value` = \'{{ cartaddprice() }}\'
+            WHERE value LIKE \'{{ cartaddprice(%\';
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -11,6 +11,7 @@
         <service id="Wbm\TagManagerEcomm\Core\Content\Property\PropertyDefinition">
             <tag name="shopware.entity.definition" entity="wbm_data_layer_properties" />
         </service>
+
         <service id="Wbm\TagManagerEcomm\Subscriber\StorefrontRenderSubscriber">
             <argument type="service" id="Wbm\TagManagerEcomm\Services\DataLayerModules" />
             <argument type="service" id="Wbm\TagManagerEcomm\Services\DataLayerRenderer" />
@@ -21,6 +22,11 @@
             <argument type="service" id="Wbm\TagManagerEcomm\Services\DataLayerRenderer" />
             <tag name="kernel.event_subscriber" />
         </service>
+        <service id="Wbm\TagManagerEcomm\Subscriber\CartAddPrice\AfterLineItemAddedSubscriber">
+            <argument type="service" id="session" />
+            <tag name="kernel.event_subscriber" />
+        </service>
+
         <service id="Wbm\TagManagerEcomm\Services\DataLayerModules">
             <argument type="service" id="Doctrine\DBAL\Connection" />
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -15,15 +15,17 @@
         <service id="Wbm\TagManagerEcomm\Subscriber\StorefrontRenderSubscriber">
             <argument type="service" id="Wbm\TagManagerEcomm\Services\DataLayerModules" />
             <argument type="service" id="Wbm\TagManagerEcomm\Services\DataLayerRenderer" />
+            <argument type="service" id="Wbm\TagManagerEcomm\Utility\SessionUtility" />
             <tag name="kernel.event_subscriber" />
         </service>
         <service id="Wbm\TagManagerEcomm\Subscriber\KernelEventsSubscriber">
             <argument type="service" id="Wbm\TagManagerEcomm\Services\DataLayerModules" />
             <argument type="service" id="Wbm\TagManagerEcomm\Services\DataLayerRenderer" />
+            <argument type="service" id="Wbm\TagManagerEcomm\Utility\SessionUtility" />
             <tag name="kernel.event_subscriber" />
         </service>
         <service id="Wbm\TagManagerEcomm\Subscriber\CartAddPrice\AfterLineItemAddedSubscriber">
-            <argument type="service" id="session" />
+            <argument type="service" id="Wbm\TagManagerEcomm\Utility\SessionUtility" />
             <tag name="kernel.event_subscriber" />
         </service>
 
@@ -35,6 +37,8 @@
             <argument type="service" id="twig" />
             <argument type="service" id="Doctrine\DBAL\Connection" />
         </service>
+        <service id="Wbm\TagManagerEcomm\Utility\SessionUtility" />
+
         <service id="Wbm\TagManagerEcomm\Twig\TagManagerExtension">
             <argument type="service" id="Doctrine\DBAL\Connection" />
             <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService" />

--- a/src/Subscriber/CartAddPrice/AfterLineItemAddedSubscriber.php
+++ b/src/Subscriber/CartAddPrice/AfterLineItemAddedSubscriber.php
@@ -6,17 +6,15 @@ namespace Wbm\TagManagerEcomm\Subscriber\CartAddPrice;
 
 use Shopware\Core\Checkout\Cart\Event\AfterLineItemAddedEvent;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
-use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\Session\Session;
 use Wbm\TagManagerEcomm\Utility\SessionUtility;
 
 class AfterLineItemAddedSubscriber implements EventSubscriberInterface
 {
-    protected Session $session;
+    protected SessionUtility $session;
 
-    public function __construct(Session $session)
+    public function __construct(SessionUtility $session)
     {
         $this->session = $session;
     }

--- a/src/Subscriber/CartAddPrice/AfterLineItemAddedSubscriber.php
+++ b/src/Subscriber/CartAddPrice/AfterLineItemAddedSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wbm\TagManagerEcomm\Subscriber\CartAddPrice;
+
+use Shopware\Core\Checkout\Cart\Event\AfterLineItemAddedEvent;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Wbm\TagManagerEcomm\Utility\SessionUtility;
+
+class AfterLineItemAddedSubscriber implements EventSubscriberInterface
+{
+    protected Session $session;
+
+    public function __construct(Session $session)
+    {
+        $this->session = $session;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            AfterLineItemAddedEvent::class => 'onAfterLineItemAdded'
+        ];
+    }
+
+    public function onAfterLineItemAdded(AfterLineItemAddedEvent $event)
+    {
+        if (!$this->session->has(SessionUtility::UPDATE_FLAG)
+            || $this->session->get(SessionUtility::UPDATE_FLAG) !== SessionUtility::ADDCART_UPDATEFLAG_VALUE) {
+            return;
+        }
+
+        $lineItems = [];
+        /** @var LineItem $addedLineItem */
+        foreach ($event->getLineItems() as $addedLineItem) {
+            $cartLineItem = $event->getCart()->getLineItems()->get($addedLineItem->getId());
+            if (!$cartLineItem instanceof LineItem || !$cartLineItem->getPrice() instanceof CalculatedPrice) {
+                continue;
+            }
+
+            $lineItems[$cartLineItem->getPayload()['productNumber']] = $cartLineItem->getPrice()->getUnitPrice();
+        }
+
+        $this->session->set(SessionUtility::ADDCART_CART_ITEMS, $lineItems);
+    }
+}

--- a/src/Subscriber/KernelEventsSubscriber.php
+++ b/src/Subscriber/KernelEventsSubscriber.php
@@ -3,8 +3,6 @@
 namespace Wbm\TagManagerEcomm\Subscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;

--- a/src/Subscriber/StorefrontRenderSubscriber.php
+++ b/src/Subscriber/StorefrontRenderSubscriber.php
@@ -21,12 +21,19 @@ class StorefrontRenderSubscriber implements EventSubscriberInterface
      */
     private $dataLayerRenderer;
 
+    /**
+     * @var SessionUtility
+     */
+    private $session;
+
     public function __construct(
         DataLayerModules $modules,
-        DataLayerRenderer $dataLayerRenderer
+        DataLayerRenderer $dataLayerRenderer,
+        SessionUtility $session
     ) {
         $this->modules = $modules;
         $this->dataLayerRenderer = $dataLayerRenderer;
+        $this->session = $session;
     }
 
     public static function getSubscribedEvents(): array
@@ -47,7 +54,7 @@ class StorefrontRenderSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $storedDatalayer = $event->getRequest()->getSession()->get(SessionUtility::ATTRIBUTE_NAME);
+        $storedDatalayer = $this->session->get(SessionUtility::ATTRIBUTE_NAME);
         if ($storedDatalayer) {
             if (in_array($route, $this->modules->getResponseRoutes(), true)) {
                 $dataLayer = json_decode($storedDatalayer, true);
@@ -57,8 +64,7 @@ class StorefrontRenderSubscriber implements EventSubscriberInterface
             $modules = $this->modules->getModules();
 
             if (array_key_exists($route, $modules)) {
-                $dataLayer = $this->dataLayerRenderer->setVariables($route, $parameters)
-                    ->renderDataLayer($route);
+                $dataLayer = $this->dataLayerRenderer->setVariables($route, $parameters)->renderDataLayer($route);
                 $dataLayer = $dataLayer->getDataLayer($route);
             }
         }

--- a/src/Twig/TagManagerExtension.php
+++ b/src/Twig/TagManagerExtension.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
+use Wbm\TagManagerEcomm\Utility\SessionUtility;
 
 class TagManagerExtension extends AbstractExtension
 {
@@ -168,36 +169,12 @@ class TagManagerExtension extends AbstractExtension
         string $stackable = '1',
         string $removable = '1'
     ): float {
-        $salesChannelContext = $this->getSalesChannelContext($twigContext);
+        $session = $this->requestStack->getMasterRequest()->getSession();
+        $session->set(SessionUtility::UPDATE_FLAG, SessionUtility::ADDCART_UPDATEFLAG_VALUE);
+        // quickfix: price will be saved to session in AfterLineItemAddedSubscriber
+        // and before passing it to FE the correct price will be injected into datalayer
 
-        $lineItem = new LineItem(
-            $uuid,
-            $type,
-            $referencedId,
-            (int) $quantity
-        );
-        $lineItem->setStackable((bool) $stackable);
-        $lineItem->setRemovable((bool) $removable);
-        $lineItem->markModified();
-
-        $temporaryCart = $this->cartService->createNew(
-            \uniqid('temporaryToken.', true),
-            $salesChannelContext->getSalesChannel()->getName() ?: CartService::SALES_CHANNEL
-        );
-
-        // import current basket to consider all rules
-        $actualCart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext);
-        foreach ($actualCart->getLineItems() as $actualLineItem) {
-            $temporaryCart->add($actualLineItem);
-        }
-
-        $temporaryCart->add($lineItem);
-        $temporaryCart->markModified();
-        $this->cartRuleLoader->loadByCart($salesChannelContext, $temporaryCart, new CartBehavior());
-
-        $lineItem = $temporaryCart->getLineItems()->get($uuid);
-
-        return ($lineItem && $lineItem->getPrice()) ? $lineItem->getPrice()->getUnitPrice() : 0;
+        return 0;
     }
 
     public function cartremoveprice(

--- a/src/Twig/TagManagerExtension.php
+++ b/src/Twig/TagManagerExtension.php
@@ -160,18 +160,11 @@ class TagManagerExtension extends AbstractExtension
         return $salesChannelContext->getCurrency()->getIsoCode();
     }
 
-    public function cartaddprice(
-        $twigContext,
-        string $uuid = '',
-        string $quantity = '1',
-        string $type = 'product',
-        string $referencedId = '',
-        string $stackable = '1',
-        string $removable = '1'
-    ): float {
+    public function cartaddprice(): int
+    {
         $session = $this->requestStack->getMasterRequest()->getSession();
         $session->set(SessionUtility::UPDATE_FLAG, SessionUtility::ADDCART_UPDATEFLAG_VALUE);
-        // quickfix: price will be saved to session in AfterLineItemAddedSubscriber
+        // price will be saved to session in "Subscriber/AddToCart/AfterLineItemAddedSubscriber"
         // and before passing it to FE the correct price will be injected into datalayer
 
         return 0;

--- a/src/Utility/SessionUtility.php
+++ b/src/Utility/SessionUtility.php
@@ -2,7 +2,9 @@
 
 namespace Wbm\TagManagerEcomm\Utility;
 
-class SessionUtility
+use Symfony\Component\HttpFoundation\Session\Session;
+
+class SessionUtility extends Session
 {
     public const ATTRIBUTE_NAME = 'wbm-stored-datalayer';
 
@@ -10,4 +12,31 @@ class SessionUtility
 
     public const ADDCART_UPDATEFLAG_VALUE = 'cartaddprice';
     public const ADDCART_CART_ITEMS = 'wbm-stored-addCart-addedCartItems';
+
+    public function injectSessionVars(array $dataLayer): array
+    {
+        if (!$this->has(self::UPDATE_FLAG)) {
+            return $dataLayer;
+        }
+
+        if ($this->get(self::UPDATE_FLAG) === self::ADDCART_UPDATEFLAG_VALUE) {
+            try {
+                foreach ($dataLayer as &$dLayer) {
+                    $dLayer = json_decode($dLayer, true, 512, JSON_THROW_ON_ERROR);
+                    foreach ($dLayer['ecommerce']['add']['products'] as &$product) {
+                        $lineItems = $this->get(self::ADDCART_CART_ITEMS);
+                        $product['price'] = $lineItems[$product['id']];
+                    }
+                    unset($product);
+                    $dLayer = json_encode($dLayer);
+                }
+            } catch (\Throwable $t) {
+                // just to make sure session vars are removed on error
+            }
+            $this->remove(self::UPDATE_FLAG);
+            $this->remove(self::ADDCART_CART_ITEMS);
+        }
+
+        return $dataLayer;
+    }
 }

--- a/src/Utility/SessionUtility.php
+++ b/src/Utility/SessionUtility.php
@@ -5,4 +5,9 @@ namespace Wbm\TagManagerEcomm\Utility;
 class SessionUtility
 {
     public const ATTRIBUTE_NAME = 'wbm-stored-datalayer';
+
+    public const UPDATE_FLAG = 'wbm-stored-shouldUpdate';
+
+    public const ADDCART_UPDATEFLAG_VALUE = 'cartaddprice';
+    public const ADDCART_CART_ITEMS = 'wbm-stored-addCart-addedCartItems';
 }


### PR DESCRIPTION
Closes #34 

Save the calculated price from shopware into session and inject these values into datalayer right before prepending it to response - instead of create a new cart and calculating it again. Also the useless temporary carts will be deleted by migration.